### PR TITLE
Switch to rust-stable

### DIFF
--- a/io.github.neil_morrison44.pocket-sync.yaml
+++ b/io.github.neil_morrison44.pocket-sync.yaml
@@ -5,7 +5,7 @@ runtime-version: '42'
 sdk: org.gnome.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.node16
-  - org.freedesktop.Sdk.Extension.rust-nightly
+  - org.freedesktop.Sdk.Extension.rust-stable
 command: pocket-sync
 rename-icon: pocket-sync
 separate-locales: false
@@ -21,7 +21,7 @@ modules:
   - name: pocket-sync
     buildsystem: simple
     build-options:
-      append-path: /usr/lib/sdk/node16/bin:/usr/lib/sdk/rust-nightly/bin
+      append-path: /usr/lib/sdk/node16/bin:/usr/lib/sdk/rust-stable/bin
       env:
         npm_config_nodedir: /usr/lib/sdk/node16
         npm_config_offline: 'true'


### PR DESCRIPTION
rust-nightly is being deprecated by Flathub

cc @hadess cc @neil-morrison44 

I believe you don't need rust nightly as you are using an outdated `branch/21.08` of it which hasn't received updates in 2 years. The 21.08 branch of rust nightly got deprecated when the 21.08 runtime was deprecated.

In the future when you upgrade runtimes and rust-nightly is required, please bundle the version you need and clean it up later with `cleanup: ["*"]`.