### PR TITLE
Correct app name in desktop and appdata files

### DIFF
--- a/io.github.neil_morrison44.pocket-sync.appdata.xml
+++ b/io.github.neil_morrison44.pocket-sync.appdata.xml
@@ -2,7 +2,7 @@
 <component type="desktop-application">
   <id>io.github.neil_morrison44.pocket-sync</id>
 
-  <name>pocket-sync</name>
+  <name>Pocket Sync</name>
   <summary>A GUI to do stuff with the Analogue Pocket</summary>
   <developer_name>Neil Morrison</developer_name>
 

--- a/io.github.neil_morrison44.pocket-sync.desktop
+++ b/io.github.neil_morrison44.pocket-sync.desktop
@@ -1,8 +1,7 @@
 [Desktop Entry]
 Version=1.0
 Type=Application
-
-Name=pocket-sync
+Name=Pocket Sync
 Comment=A GUI to do stuff with the Analogue Pocket
 Icon=pocket-sync
 Exec=pocket-sync


### PR DESCRIPTION
The app names itself "Pocket Sync" in its window title, so match that in the desktop and appdata files.